### PR TITLE
fix: use browser jsonlint build

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ body.invalid svg.logo { color:#dc2626; }
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/scroll/annotatescrollbar.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/search/matchesonscrollbar.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/addon/search/jump-to-line.min.js"></script>
-<script src="https://unpkg.com/jsonlint-mod@1.7.6/lib/jsonlint.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jsonlint-mod@1.7.6/dist/jsonlint.min.js"></script>
 <script>
 const editor = CodeMirror.fromTextArea(document.getElementById('editor'), {
     mode: { name: 'javascript', json: true },


### PR DESCRIPTION
## Summary
- load browser-ready jsonlint module instead of node-only build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bfef15bdcc832f8261f310d6ea5675