### PR TITLE
Fix default text and heading styling for JSONLint

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,14 @@
 <style>
 .cm-error-highlight { background-color: rgba(255,0,0,0.2); }
 .CodeMirror { min-height:500px; resize:vertical; overflow:auto; font-family: monospace; font-size:12px; }
+body { color:#000; }
+h1 { font-weight:700; color:#000; }
+h2 { font-size:1.25rem; font-weight:600; color:#000; margin-top:2.5rem; }
 body.valid svg.logo { color:#16a34a; }
 body.invalid svg.logo { color:#dc2626; }
 </style>
 </head>
-<body class="dark:text-slate-300">
+<body class="text-black dark:text-slate-300">
 <div class="mt-8 max-w-8xl mx-auto sticky top-ad-container top-0 z-10 px-8 lg:px-10 flex">
     <div id="bsa-zone_1570746984891-3_123456"></div>
 </div>


### PR DESCRIPTION
## Summary
- ensure body and headings render in black with bold text
- define default heading sizes so section titles appear correctly

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bff62a7820832fbe22f38c6c2e237e