### PR TITLE
Fix prettify conversion to use real tabs

### DIFF
--- a/components/jsonlint.js
+++ b/components/jsonlint.js
@@ -31,7 +31,15 @@ function customStringify(jsonObject, pretty) {
 
 function convertSpacesToTabs(str, spacesPerIndent) {
     const spaceGroup = ' '.repeat(spacesPerIndent)
-    return str.split('\n').map(line => line.replace(new RegExp(`^(${spaceGroup})+`, 'g'), match => '\t'.repeat(match.length / spacesPerIndent))).join('\n')
+    return str
+        .split('\n')
+        .map(line =>
+            line.replace(
+                new RegExp(`^(${spaceGroup})+`, 'g'),
+                match => String.fromCharCode(9).repeat(match.length / spacesPerIndent)
+            )
+        )
+        .join('\n')
 }
 
 function customCompress(jsonString) {


### PR DESCRIPTION
## Summary
- ensure Prettify replaces spaces with real tab characters instead of literal `\t`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c001b43838832fb4493b2a3ac6ada1